### PR TITLE
Use pydicom as fallback from SimpleITK's GDCM

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 SimpleITK >= 2.0.0rc2
 numpy
 scikit-learn
+pydicom


### PR DESCRIPTION
To improve robustness, when GDCM fails to load the DICOM file,
fallback to use pydicom.