### PR TITLE
Update default pca model

### DIFF
--- a/tbpcxr/model.py
+++ b/tbpcxr/model.py
@@ -125,7 +125,7 @@ class Model(ABC):
         """
         :return: A pre-trained PCAModel object to detect outliers or abnormal CXR images.
         """
-        return __class__.load_model("pca-001")
+        return __class__.load_model("pca-35-06c")
 
     @staticmethod
     def load_model(name: str) -> 'Model':

--- a/tbpcxr/model/pca-001.pkl
+++ b/tbpcxr/model/pca-001.pkl
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:06084e00228a790cbcaa034be45fee6cb08ae5ac19d198e7e2013494213875c1
-size 443963

--- a/tbpcxr/model/pca-35-06c.pkl
+++ b/tbpcxr/model/pca-35-06c.pkl
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2b9229691e1bf606d1f799483933b9586a488de332b3550e09e407297ecd2b9f
+size 576426


### PR DESCRIPTION
This model was developed by the CXR Outlier Training Notebooks. It has
a PCA with 35 components and 6% contamination from the high quality
training TBP data.