### PR TITLE
Update to sckit learn 1.3

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 SimpleITK >= 2.0.0
 numpy
-scikit-learn ~= 0.24.2
+scikit-learn ~= 1.3.0
 # Hosted on artifactory.niaid.nih.gov in bcbb-pypi
 rap_sitkcore

--- a/tbpcxr/model/pca-35-06c.pkl
+++ b/tbpcxr/model/pca-35-06c.pkl
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:2b9229691e1bf606d1f799483933b9586a488de332b3550e09e407297ecd2b9f
-size 576426
+oid sha256:7ff173a0b77c127aa45ed4b7cdcc3e8d864fbf371a7dd384f71117ecf2702a20
+size 576087


### PR DESCRIPTION
Migrated the save pickled model by loading, validating and saving with the newer version of scikit learn. Validation was performed with 400 CXR images from the NIH clinical center dataset. The PCA residuals where compared to be with in ~0.001 with the old version and 1.3.0 of scikit learn. The resulting outlier classification matched for all test cases.